### PR TITLE
feat(config): adds multiline + json configset

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -102,6 +102,7 @@ RUN cp conf/parsers*.conf /fluent-bit/etc
 RUN cp conf/parsers*.conf /fluent-bit/parsers/
 
 ADD configs/parse-json.conf /fluent-bit/configs/
+ADD configs/multiline-parse-json.conf /fluent-bit/configs/
 ADD configs/minimize-log-loss.conf /fluent-bit/configs/
 ADD configs/output-metrics-healthcheck.conf /fluent-bit/configs/
 ADD configs/plugin-metrics-to-cloudwatch.conf /fluent-bit/configs/

--- a/Makefile
+++ b/Makefile
@@ -15,10 +15,7 @@ all: release
 
 .PHONY: release
 release: linux-plugins
-	docker system prune -f
-	docker build -t amazon/aws-for-fluent-bit:latest -f Dockerfile .
-	docker system prune -f
-	docker build -t amazon/aws-for-fluent-bit:init-latest -f Dockerfile.init .
+	docker build -t superbxp/aws-for-fluent-bit:latest -f Dockerfile .
 
 #TODO: the bash script opts does not work on developer Macs
 windows-plugins: export OS_TYPE = windows

--- a/configs/multiline-parse-json.conf
+++ b/configs/multiline-parse-json.conf
@@ -1,0 +1,19 @@
+[SERVICE]
+    Parsers_File /fluent-bit/parsers/parsers.conf
+    Flush 1
+    Grace 30
+
+# Aggregate docker partial messages
+# Learn more: https://docs.fluentbit.io/manual/pipeline/filters/multiline-stacktrace#docker-partial-message-use-case
+[FILTER]
+    Name multiline
+    Match *
+    Multiline.key_content log
+    Mode partial_message
+
+[FILTER]
+    Name parser
+    Match *
+    Key_Name log
+    Parser json
+    Reserve_Data True


### PR DESCRIPTION
## What

It  adds a new configuration set that aggregates docker logs multiline and then convert to JSON objects.

## Why

Docker truncates log messages into chunks of 16k.

## Tests

It was tested in staging. It worked as expected.

**PS:** The image `superbxp/aws-for-fluent-bit:latest` was already updated and tested.